### PR TITLE
Replaced fs-jetpack with promised functions from fs and fs-extra.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 build/
 tasks/
 lib/
+.idea/
 npm-debug.log
 SquirrelSetup.log
 .node-version

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "bluebird": "^3.3.4",
     "debug": "^2.2.0",
     "fs-extra": "^0.26.7",
-    "fs-jetpack": "^0.7.3",
     "lodash.template": "^4.2.2",
     "temp": "^0.8.3"
   },

--- a/spec/installer-spec.js
+++ b/spec/installer-spec.js
@@ -1,29 +1,24 @@
-import temp from 'temp';
-import jetpack from 'fs-jetpack';
-import sfs from 'fs';
 import path from 'path';
-
+import { createTempDir, existsFileAsync, unlinkAsync, readDirAsync } from '../src/fs-utils';
 import { createWindowsInstaller } from '../src/index.js';
-
-temp.track();
 
 const d = require('debug')('electron-windows-installer:spec');
 
 describe('create-windows-installer task', function() {
   beforeEach(async function() {
-    let updateExePath = path.join(__dirname, 'fixtures', 'app', 'Update.exe');
-    if (await jetpack.existsAsync(updateExePath)) {
-      // NB: Jetpack doesn't have unlink?
-      sfs.unlinkSync(updateExePath);
+    const updateExePath = path.join(__dirname, 'fixtures', 'app', 'Update.exe');
+    if (await existsFileAsync(updateExePath)) {
+
+      await unlinkAsync(updateExePath);
     }
   });
 
   it('creates a nuget package and installer', async function() {
     this.timeout(30*1000);
 
-    let outputDirectory = temp.mkdirSync('ei-');
+    const outputDirectory = await createTempDir('ei-');
 
-    let options = {
+    const options = {
       appDirectory: path.join(__dirname, 'fixtures/app'),
       outputDirectory: outputDirectory
     };
@@ -31,15 +26,16 @@ describe('create-windows-installer task', function() {
     await createWindowsInstaller(options);
 
     d(`Verifying assertions on ${outputDirectory}`);
-    d(JSON.stringify(sfs.readdirSync(outputDirectory)));
-    expect(await jetpack.existsAsync(path.join(outputDirectory, 'myapp-1.0.0-full.nupkg'))).to.be.ok;
-    expect(await jetpack.existsAsync(path.join(outputDirectory, 'MyAppSetup.exe'))).to.be.ok;
+    d(JSON.stringify(await readDirAsync(outputDirectory)));
+
+    expect(await existsFileAsync(path.join(outputDirectory, 'myapp-1.0.0-full.nupkg'))).to.be.ok;
+    expect(await existsFileAsync(path.join(outputDirectory, 'MyAppSetup.exe'))).to.be.ok;
 
     if (process.platform === 'win32') {
-      expect(await jetpack.existsAsync(path.join(outputDirectory, 'MyAppSetup.msi'))).to.be.ok;
+      expect(await existsFileAsync(path.join(outputDirectory, 'MyAppSetup.msi'))).to.be.ok;
     }
 
     d('Verifying Update.exe');
-    expect(await jetpack.existsAsync(path.join(__dirname, 'fixtures', 'app', 'Update.exe'))).to.be.ok;
+    expect(await existsFileAsync(path.join(__dirname, 'fixtures', 'app', 'Update.exe'))).to.be.ok;
   });
 });

--- a/spec/installer-spec.js
+++ b/spec/installer-spec.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { createTempDir, existsFileAsync, unlinkAsync, readDirAsync } from '../src/fs-utils';
+import { createTempDir, fileExists, unlink, readDir } from '../src/fs-utils';
 import { createWindowsInstaller } from '../src/index.js';
 
 const d = require('debug')('electron-windows-installer:spec');
@@ -7,9 +7,9 @@ const d = require('debug')('electron-windows-installer:spec');
 describe('create-windows-installer task', function() {
   beforeEach(async function() {
     const updateExePath = path.join(__dirname, 'fixtures', 'app', 'Update.exe');
-    if (await existsFileAsync(updateExePath)) {
+    if (await fileExists(updateExePath)) {
 
-      await unlinkAsync(updateExePath);
+      await unlink(updateExePath);
     }
   });
 
@@ -26,16 +26,16 @@ describe('create-windows-installer task', function() {
     await createWindowsInstaller(options);
 
     d(`Verifying assertions on ${outputDirectory}`);
-    d(JSON.stringify(await readDirAsync(outputDirectory)));
+    d(JSON.stringify(await readDir(outputDirectory)));
 
-    expect(await existsFileAsync(path.join(outputDirectory, 'myapp-1.0.0-full.nupkg'))).to.be.ok;
-    expect(await existsFileAsync(path.join(outputDirectory, 'MyAppSetup.exe'))).to.be.ok;
+    expect(await fileExists(path.join(outputDirectory, 'myapp-1.0.0-full.nupkg'))).to.be.ok;
+    expect(await fileExists(path.join(outputDirectory, 'MyAppSetup.exe'))).to.be.ok;
 
     if (process.platform === 'win32') {
-      expect(await existsFileAsync(path.join(outputDirectory, 'MyAppSetup.msi'))).to.be.ok;
+      expect(await fileExists(path.join(outputDirectory, 'MyAppSetup.msi'))).to.be.ok;
     }
 
     d('Verifying Update.exe');
-    expect(await existsFileAsync(path.join(__dirname, 'fixtures', 'app', 'Update.exe'))).to.be.ok;
+    expect(await fileExists(path.join(__dirname, 'fixtures', 'app', 'Update.exe'))).to.be.ok;
   });
 });

--- a/src/fs-utils.js
+++ b/src/fs-utils.js
@@ -1,0 +1,41 @@
+import { copy } from 'fs-extra';
+import { Promise } from 'bluebird';
+import temp from 'temp';
+import fs from 'fs';
+
+const log = require('debug')('electron-windows-installer:fs-utils');
+
+temp.track();
+
+const promisedCopy = Promise.promisify(copy);
+const promisedCreateTempDir = Promise.promisify(temp.mkdir);
+const readFileAsync = Promise.promisify(fs.readFile);
+const readDirAsync = Promise.promisify(fs.readdir);
+const unlinkAsync = Promise.promisify(fs.unlink);
+const writeFileAsync = Promise.promisify(fs.writeFile);
+const renameAsync = Promise.promisify(fs.rename);
+const inspectAsync = Promise.promisify(fs.stat);
+
+export {
+  promisedCopy as copy, 
+  promisedCreateTempDir as createTempDir,
+  readDirAsync,
+  unlinkAsync,
+  readFileAsync,
+  writeFileAsync,
+  inspectAsync,
+  renameAsync
+};
+
+export async function existsFileAsync(file) {
+  let stats;
+
+  try {
+    stats = await inspectAsync(file);
+    return stats.isFile();
+  } catch(err) {
+    log(err);
+  }
+
+  return false;
+}

--- a/src/fs-utils.js
+++ b/src/fs-utils.js
@@ -1,4 +1,4 @@
-import { copy } from 'fs-extra';
+import { copy as extraCopy } from 'fs-extra';
 import { Promise } from 'bluebird';
 import temp from 'temp';
 import fs from 'fs';
@@ -7,31 +7,20 @@ const log = require('debug')('electron-windows-installer:fs-utils');
 
 temp.track();
 
-const promisedCopy = Promise.promisify(copy);
-const promisedCreateTempDir = Promise.promisify(temp.mkdir);
-const readFileAsync = Promise.promisify(fs.readFile);
-const readDirAsync = Promise.promisify(fs.readdir);
-const unlinkAsync = Promise.promisify(fs.unlink);
-const writeFileAsync = Promise.promisify(fs.writeFile);
-const renameAsync = Promise.promisify(fs.rename);
-const inspectAsync = Promise.promisify(fs.stat);
+export const copy = Promise.promisify(extraCopy);
+export const createTempDir = Promise.promisify(temp.mkdir);
+export const readFile = Promise.promisify(fs.readFile);
+export const readDir = Promise.promisify(fs.readdir);
+export const unlink = Promise.promisify(fs.unlink);
+export const writeFile = Promise.promisify(fs.writeFile);
+export const rename = Promise.promisify(fs.rename);
 
-export {
-  promisedCopy as copy, 
-  promisedCreateTempDir as createTempDir,
-  readDirAsync,
-  unlinkAsync,
-  readFileAsync,
-  writeFileAsync,
-  inspectAsync,
-  renameAsync
-};
-
-export async function existsFileAsync(file) {
+const inspect = Promise.promisify(fs.stat);
+export async function fileExists(file) {
   let stats;
 
   try {
-    stats = await inspectAsync(file);
+    stats = await inspect(file);
     return stats.isFile();
   } catch(err) {
     log(err);

--- a/src/index.js
+++ b/src/index.js
@@ -2,21 +2,16 @@ import template from 'lodash.template';
 import spawn from './spawn-promise';
 import asar from 'asar';
 import path from 'path';
-import temp from 'temp';
-import jetpack from 'fs-jetpack';
-import fs from 'fs';
-import { Promise } from 'bluebird';
+import * as fsUtils from './fs-utils';
 
-const d = require('debug')('electron-windows-installer:main');
-const createTempDir = Promise.promisify(temp.mkdir);
+const log = require('debug')('electron-windows-installer:main');
 
-temp.track();
 async function statNoException(file) {
   try {
-    d(file);
-    return await jetpack.inspectAsync(file);
+    log(file);
+    return await fsUtils.inspectAsync(file);
   } catch (e) {
-    d(e.message);
+    log(e.message);
     return null;
   }
 }
@@ -27,29 +22,32 @@ async function locateExecutableInPath(exe) {
 
   // Files with any directory path don't get this applied
   if (exe.match(/[\\\/]/)) {
-    d('Path has slash in directory, bailing');
+    log('Path has slash in directory, bailing');
     return exe;
   }
 
-  let target = path.join('.', exe);
+  const target = path.join('.', exe);
   if (await statNoException(target)) {
-    d(`Found executable in currect directory: ${target}`);
+    log(`Found executable in currect directory: ${target}`);
     return target;
   }
 
-  let haystack = process.env.PATH.split(path.delimiter);
+  const haystack = process.env.PATH.split(path.delimiter);
   for (let p of haystack) {
-    let needle = path.join(p, exe);
-    if (await statNoException(needle)) return needle;
+    const needle = path.join(p, exe);
+    if (await statNoException(needle)) {
+      return needle;
+    }
   }
 
-  d('Failed to find executable anywhere in path');
+  log('Failed to find executable anywhere in path');
   return null;
 }
 
 export function convertVersion(version) {
-  let parts = version.split('-');
-  let mainVersion = parts.shift();
+  const parts = version.split('-');
+  const mainVersion = parts.shift();
+
   if (parts.length > 0) {
     return [mainVersion, parts.join('-').replace(/\./g, '')].join('-');
   } else {
@@ -59,6 +57,7 @@ export function convertVersion(version) {
 
 export async function createWindowsInstaller(options) {
   let useMono = false;
+
   const monoExe = await locateExecutableInPath('mono');
   const wineExe = await locateExecutableInPath('wine');
 
@@ -68,19 +67,20 @@ export async function createWindowsInstaller(options) {
       throw new Error('You must install both Mono and Wine on non-Windows');
     }
 
-    d(`Using Mono: '${monoExe}'`);
-    d(`Using Wine: '${wineExe}'`);
+    log(`Using Mono: '${monoExe}'`);
+    log(`Using Wine: '${wineExe}'`);
   }
+
   let { appDirectory, outputDirectory, loadingGif } = options;
   outputDirectory = path.resolve(outputDirectory || 'installer');
 
   const vendorPath = path.join(__dirname, '..', 'vendor');
-  await jetpack.copyAsync(
-    path.join(vendorPath, 'Update.exe'),
-    path.join(appDirectory, 'Update.exe'),
-    { overwrite: true });
+  const vendorUpdate = path.join(vendorPath, 'Update.exe');
+  const appUpdate = path.join(appDirectory, 'Update.exe');
 
-  let defaultLoadingGif = path.join(__dirname, '..', 'resources', 'install-spinner.gif');
+  await fsUtils.copy(vendorUpdate, appUpdate);
+
+  const defaultLoadingGif = path.join(__dirname, '..', 'resources', 'install-spinner.gif');
   loadingGif = loadingGif ? path.resolve(loadingGif) : defaultLoadingGif;
 
   let {certificateFile, certificatePassword, remoteReleases, signWithParams, remoteToken} = options;
@@ -92,13 +92,13 @@ export async function createWindowsInstaller(options) {
 
   if (options.usePackageJson !== false) {
     const appResources = path.join(appDirectory, 'resources');
-    let asarFile = path.join(appResources, 'app.asar');
+    const asarFile = path.join(appResources, 'app.asar');
     let appMetadata;
-    if (await jetpack.existsAsync(asarFile)) {
+
+    if (await fsUtils.existsFileAsync(asarFile)) {
       appMetadata = JSON.parse(asar.extractFile(asarFile, 'package.json'));
-    }
-    else {
-      appMetadata = JSON.parse(await jetpack.readAsync(path.join(appResources, 'app', 'package.json'), 'utf8'));
+    } else {
+      appMetadata = JSON.parse(await fsUtils.readFileAsync(path.join(appResources, 'app', 'package.json'), 'utf8'));
     }
 
     Object.assign(metadata, {
@@ -122,17 +122,18 @@ export async function createWindowsInstaller(options) {
   metadata.copyright = metadata.copyright ||
     `Copyright © ${new Date().getFullYear()} ${metadata.authors || metadata.owners}`;
 
-  let templateData = await jetpack.readAsync(path.join(__dirname, '..', 'template.nuspec'));
+  let templateData = await fsUtils.readFileAsync(path.join(__dirname, '..', 'template.nuspec'), 'utf8');
   if (path.sep === '/') {
     templateData = templateData.replace(/\\/g, '/');
   }
   const nuspecContent = template(templateData)(metadata);
 
-  d(`Created NuSpec file:\n${nuspecContent}`);
+  log(`Created NuSpec file:\n${nuspecContent}`);
 
-  let nugetOutput = await createTempDir('si-');
-  let targetNuspecPath = path.join(nugetOutput, metadata.name + '.nuspec');
-  await jetpack.writeAsync(targetNuspecPath, nuspecContent);
+  const nugetOutput = await fsUtils.createTempDir('si-');
+  const targetNuspecPath = path.join(nugetOutput, metadata.name + '.nuspec');
+
+  await fsUtils.writeFileAsync(targetNuspecPath, nuspecContent);
 
   let cmd = path.join(vendorPath, 'nuget.exe');
   let args = [
@@ -148,7 +149,7 @@ export async function createWindowsInstaller(options) {
   }
 
   // Call NuGet to create our package
-  d(await spawn(cmd, args));
+  log(await spawn(cmd, args));
   const nupkgPath = path.join(nugetOutput, `${metadata.name}.${metadata.version}.nupkg`);
 
   if (remoteReleases) {
@@ -164,7 +165,7 @@ export async function createWindowsInstaller(options) {
       args.push('-t', remoteToken);
     }
 
-    d(await spawn(cmd, args));
+    log(await spawn(cmd, args));
   }
 
   cmd = path.join(vendorPath, 'Update.com');
@@ -196,22 +197,22 @@ export async function createWindowsInstaller(options) {
     args.push('--no-msi');
   }
 
-  d(await spawn(cmd, args));
+  log(await spawn(cmd, args));
 
   if (options.fixUpPaths !== false && metadata.productName) {
-    d('Fixing up paths');
+    log('Fixing up paths');
+
     const setupPath = path.join(outputDirectory, `${metadata.productName}Setup.exe`);
     const setupMsiPath = path.join(outputDirectory, `${metadata.productName}Setup.msi`);
-
-    // NB: When you give jetpack two absolute paths, it acts as if './' is appended
-    // to the target and mkdirps the entire path
     const unfixedSetupPath = path.join(outputDirectory, 'Setup.exe');
-    d(`Renaming ${unfixedSetupPath} => ${setupPath}`);
-    fs.renameSync(unfixedSetupPath, setupPath);
+
+    log(`Renaming ${unfixedSetupPath} => ${setupPath}`);
+
+    await fsUtils.renameAsync(unfixedSetupPath, setupPath);
 
     const msiPath = path.join(outputDirectory, 'Setup.msi');
-    if (jetpack.exists(msiPath)) {
-      fs.renameSync(msiPath, setupMsiPath);
+    if (await fsUtils.existsFileAsync(msiPath)) {
+      await fsUtils.renameAsync(msiPath, setupMsiPath);
     }
   }
 }


### PR DESCRIPTION
fs-jetpack uses Q instead of bluebird, Q doesn't support long stack traces.
Also jetpack had wrong behavior with absolute paths.
Cleaned up es6.
Added .editorconfig.

@develar could you please review this patch?

/cc @paulcbetts @kevinsawicki            