### PR TITLE
Set the Update.exe icon appropriately

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,15 @@ export async function createWindowsInstaller(options) {
   const appUpdate = path.join(appDirectory, 'Update.exe');
 
   await fsUtils.copy(vendorUpdate, appUpdate);
+  if (options.setupIcon) {
+    let cmd = path.join(vendorPath, 'rcedit.exe');
+    let args = [
+      appUpdate,
+      '--set-icon', options.setupIcon
+    ];
+
+    await spawn(cmd, args);
+  }
 
   const defaultLoadingGif = path.join(__dirname, '..', 'resources', 'install-spinner.gif');
   loadingGif = loadingGif ? path.resolve(loadingGif) : defaultLoadingGif;


### PR DESCRIPTION
This sets `Update.exe` to have the same icon as your generated Setup executable.