### PR TITLE
Add `setupExe` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ There are several configuration settings supported:
 | `signWithParams`      | No       | Params to pass to signtool.  Overrides `certificateFile` and `certificatePassword`. |
 | `iconUrl`             | No       | A URL to an ICO file to use as the application icon (displayed in Control Panel > Programs and Features). Defaults to the Atom icon. |
 | `setupIcon`           | No       | The ICO file to use as the icon for the generated Setup.exe |
+| `setupExe`            | No       | The name to use for the generated Setup.exe file |
 | `noMsi`               | No       | Should Squirrel.Windows create an MSI installer? |
 | `remoteReleases`      | No       | A URL to your existing updates. If given, these will be downloaded to create delta updates |
 | `remoteToken`      | No       | Authentication token for remote updates |

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ export async function createWindowsInstaller(options) {
   if (options.fixUpPaths !== false && metadata.productName) {
     log('Fixing up paths');
 
-    const setupPath = path.join(outputDirectory, `${metadata.productName}Setup.exe`);
+    const setupPath = path.join(outputDirectory, options.setupExe || `${metadata.productName}Setup.exe`);
     const setupMsiPath = path.join(outputDirectory, `${metadata.productName}Setup.msi`);
     const unfixedSetupPath = path.join(outputDirectory, 'Setup.exe');
 


### PR DESCRIPTION
This lets the user select a name for the generated `Setup.exe` file.