### PR TITLE
Set Update.exe icon using wine when available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,11 @@ export async function createWindowsInstaller(options) {
       '--set-icon', options.setupIcon
     ];
 
+    if (useMono) {
+      args.unshift(cmd);
+      cmd = wineExe;
+    }
+
     await spawn(cmd, args);
   }
 


### PR DESCRIPTION
Invoke `rcedit.exe` through `wine` when available so you can set the `Update.exe` icon when building your installer from Mac/Linux.

Follow on to #59

Previously it would fail with the following error on Mac/Linux:

```
Error: spawn EACCES
    at exports._errnoException (util.js:870:11)
    at ChildProcess.spawn (internal/child_process.js:298:11)
    at exports.spawn (child_process.js:362:9)
```