### PR TITLE
Fixup setup path when setupExe but no productName

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -218,6 +218,7 @@ export async function createWindowsInstaller(options) {
       const setupMsiPath = path.join(outputDirectory, `${metadata.productName}Setup.msi`);
       const msiPath = path.join(outputDirectory, 'Setup.msi');
       if (await fsUtils.fileExists(msiPath)) {
+        log(`Renaming ${msiPath} => ${setupMsiPath}`);
         await fsUtils.rename(msiPath, setupMsiPath);
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -214,11 +214,11 @@ export async function createWindowsInstaller(options) {
     }
 
     if (metadata.productName) {
-      const setupMsiPath = path.join(outputDirectory, `${metadata.productName}Setup.msi`);
+      const msiPath = path.join(outputDirectory, `${metadata.productName}Setup.msi`);
       const unfixedMsiPath = path.join(outputDirectory, 'Setup.msi');
       if (await fsUtils.fileExists(unfixedMsiPath)) {
-        log(`Renaming ${unfixedMsiPath} => ${setupMsiPath}`);
-        await fsUtils.rename(msiPath, setupMsiPath);
+        log(`Renaming ${unfixedMsiPath} => ${msiPath}`);
+        await fsUtils.rename(msiPath, msiPath);
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ export async function createWindowsInstaller(options) {
   if (options.fixUpPaths !== false) {
     log('Fixing up paths');
 
-    if (options.setupExe || metadata.productName) {
+    if (metadata.productName || options.setupExe) {
       const setupPath = path.join(outputDirectory, options.setupExe || `${metadata.productName}Setup.exe`);
       const unfixedSetupPath = path.join(outputDirectory, 'Setup.exe');
 

--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,6 @@ export async function createWindowsInstaller(options) {
     if (metadata.productName || options.setupExe) {
       const setupPath = path.join(outputDirectory, options.setupExe || `${metadata.productName}Setup.exe`);
       const unfixedSetupPath = path.join(outputDirectory, 'Setup.exe');
-
       log(`Renaming ${unfixedSetupPath} => ${setupPath}`);
       await fsUtils.rename(unfixedSetupPath, setupPath);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,6 @@ export async function createWindowsInstaller(options) {
     log('Fixing up paths');
 
     const setupPath = path.join(outputDirectory, options.setupExe || `${metadata.productName}Setup.exe`);
-    const setupMsiPath = path.join(outputDirectory, `${metadata.productName}Setup.msi`);
     const unfixedSetupPath = path.join(outputDirectory, 'Setup.exe');
 
     log(`Renaming ${unfixedSetupPath} => ${setupPath}`);
@@ -216,6 +215,7 @@ export async function createWindowsInstaller(options) {
 
     const msiPath = path.join(outputDirectory, 'Setup.msi');
     if (await fsUtils.fileExists(msiPath)) {
+      const setupMsiPath = path.join(outputDirectory, `${metadata.productName}Setup.msi`);
       await fsUtils.rename(msiPath, setupMsiPath);
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -216,9 +216,9 @@ export async function createWindowsInstaller(options) {
 
     if (metadata.productName) {
       const setupMsiPath = path.join(outputDirectory, `${metadata.productName}Setup.msi`);
-      const msiPath = path.join(outputDirectory, 'Setup.msi');
-      if (await fsUtils.fileExists(msiPath)) {
-        log(`Renaming ${msiPath} => ${setupMsiPath}`);
+      const unfixedMsiPath = path.join(outputDirectory, 'Setup.msi');
+      if (await fsUtils.fileExists(unfixedMsiPath)) {
+        log(`Renaming ${unfixedMsiPath} => ${setupMsiPath}`);
         await fsUtils.rename(msiPath, setupMsiPath);
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,7 @@ export async function createWindowsInstaller(options) {
       const unfixedMsiPath = path.join(outputDirectory, 'Setup.msi');
       if (await fsUtils.fileExists(unfixedMsiPath)) {
         log(`Renaming ${unfixedMsiPath} => ${msiPath}`);
-        await fsUtils.rename(msiPath, msiPath);
+        await fsUtils.rename(unfixedMsiPath, msiPath);
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -203,20 +203,23 @@ export async function createWindowsInstaller(options) {
 
   log(await spawn(cmd, args));
 
-  if (options.fixUpPaths !== false && metadata.productName) {
+  if (options.fixUpPaths !== false) {
     log('Fixing up paths');
 
-    const setupPath = path.join(outputDirectory, options.setupExe || `${metadata.productName}Setup.exe`);
-    const unfixedSetupPath = path.join(outputDirectory, 'Setup.exe');
+    if (options.setupExe || metadata.productName) {
+      const setupPath = path.join(outputDirectory, options.setupExe || `${metadata.productName}Setup.exe`);
+      const unfixedSetupPath = path.join(outputDirectory, 'Setup.exe');
 
-    log(`Renaming ${unfixedSetupPath} => ${setupPath}`);
+      log(`Renaming ${unfixedSetupPath} => ${setupPath}`);
+      await fsUtils.rename(unfixedSetupPath, setupPath);
+    }
 
-    await fsUtils.rename(unfixedSetupPath, setupPath);
-
-    const msiPath = path.join(outputDirectory, 'Setup.msi');
-    if (await fsUtils.fileExists(msiPath)) {
+    if (metadata.productName) {
       const setupMsiPath = path.join(outputDirectory, `${metadata.productName}Setup.msi`);
-      await fsUtils.rename(msiPath, setupMsiPath);
+      const msiPath = path.join(outputDirectory, 'Setup.msi');
+      if (await fsUtils.fileExists(msiPath)) {
+        await fsUtils.rename(msiPath, setupMsiPath);
+      }
     }
   }
 }


### PR DESCRIPTION
Previously if the `setupExe` option was specified but not `productName` then the `Setup.exe` would not get renamed since their was a `productName` check earlier to enter the rename block that would not pass.

This pull request changes that so that `Setup.exe` will be renamed if `productName` **or** `setupExe` is specified.

This also adds logging when the `.msi` path is renamed for consistency with the logging done for the `Setup.exe` rename.

Follow on to #60 

/cc @feross 