### PR TITLE
Add option to skip setting update icon

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export async function createWindowsInstaller(options) {
   const appUpdate = path.join(appDirectory, 'Update.exe');
 
   await fsUtils.copy(vendorUpdate, appUpdate);
-  if (options.setupIcon) {
+  if (options.setupIcon && options.skipUpdateIcon !== false) {
     let cmd = path.join(vendorPath, 'rcedit.exe');
     let args = [
       appUpdate,

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export async function createWindowsInstaller(options) {
   const appUpdate = path.join(appDirectory, 'Update.exe');
 
   await fsUtils.copy(vendorUpdate, appUpdate);
-  if (options.setupIcon && options.skipUpdateIcon !== false) {
+  if (options.setupIcon && (options.skipUpdateIcon !== false)) {
     let cmd = path.join(vendorPath, 'rcedit.exe');
     let args = [
       appUpdate,

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export async function createWindowsInstaller(options) {
   const appUpdate = path.join(appDirectory, 'Update.exe');
 
   await fsUtils.copy(vendorUpdate, appUpdate);
-  if (options.setupIcon && (options.skipUpdateIcon !== false)) {
+  if (options.setupIcon && (options.skipUpdateIcon === true)) {
     let cmd = path.join(vendorPath, 'rcedit.exe');
     let args = [
       appUpdate,

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export async function createWindowsInstaller(options) {
   const appUpdate = path.join(appDirectory, 'Update.exe');
 
   await fsUtils.copy(vendorUpdate, appUpdate);
-  if (options.setupIcon && (options.skipUpdateIcon === true)) {
+  if (options.setupIcon && (options.skipUpdateIcon !== true)) {
     let cmd = path.join(vendorPath, 'rcedit.exe');
     let args = [
       appUpdate,


### PR DESCRIPTION
I'm seeing a weird issue where calling `rcedit.exe --set-icon` on the `Update.exe` through wine is corrupting it somehow and making it non-launchable.

<img width="299" alt="screen shot 2016-04-12 at 9 49 49 am" src="https://cloud.githubusercontent.com/assets/671378/14470512/d2ca8ccc-009e-11e6-9e2f-721e2343b489.png">

So this pull request adds an option called `skipUpdateIcon` that will start out as undocumented so that people can disable changing the `Update.exe` icon but still have the `Setup.exe` icon set.

I was am using Wine 1.8.1 on Mac OS X 10.10.5 and seeing it fail to launch on Windows 10

