### PR TITLE
Upgrade asar to drop dependency on deprecated graceful-fs@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tdd": "ava --watch"
   },
   "dependencies": {
-    "asar": "~0.10.0",
+    "asar": "^0.11.0",
     "bluebird": "^3.3.4",
     "debug": "^2.2.0",
     "fs-extra": "^0.26.7",


### PR DESCRIPTION
Cf. #83 for report.

(tilde would work just as well as caret, might make sense since asar is in 0.x — alternatively, asar could be updated to [respect semver](https://docs.npmjs.com/getting-started/semantic-versioning#semver-for-publishers))