### PR TITLE
add: *.txt & LICENSES.chromium.html files to nuspec

### DIFF
--- a/template.nuspectemplate
+++ b/template.nuspectemplate
@@ -17,9 +17,11 @@
     <file src="*.bin" target="lib\net45" />
     <file src="*.dll" target="lib\net45" />
     <file src="*.pak" target="lib\net45" />
+    <file src="*.txt" target="lib\net45" />
     <file src="Update.exe" target="lib\net45\squirrel.exe" />
     <file src="icudtl.dat" target="lib\net45\icudtl.dat" />
     <file src="LICENSE" target="lib\net45\LICENSE" />
+    <file src="LICENSES.chromium.html" target="lib\net45\LICENSES.chromium.html" />
     <file src="<%- exe %>" target="lib\net45\<%- exe %>" />
   </files>
 </package>


### PR DESCRIPTION
Following change adds the Chromium Licenses HTML file to the Installer as it's not shipped with it currently.

![licenses chromium](https://cloud.githubusercontent.com/assets/5372612/17923153/57bb8998-6a00-11e6-9041-11e5f467d0b0.PNG)

Also, I am using a 3rd Party notices file like [VS Code](https://github.com/Microsoft/vscode/blob/master/ThirdPartyNotices.txt) and It's right next to the LICENSE file. So I added text files for packaging also.

Fixes #131 
