### PR TITLE
Add 'os' property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "test": "npm run lint && ava",
     "tdd": "ava --watch"
   },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
   "dependencies": {
     "asar": "^0.11.0",
     "bluebird": "^3.3.4",


### PR DESCRIPTION
By setting the [`os` property](https://docs.npmjs.com/files/package.json#os) in `package.json`, downstream/consuming packages, such as electron-forge (https://github.com/isleofcode/electron-forge/commit/37b373cfe1c36a94c1d0a9af260b150565bc98a3) are able to tell whether or not they can run this package on the platform they're using.

I'm not sure if the list I've proposed in this PR is appropriate, but I think this concept could be useful, for example, when certain platforms are known not to work.

See also https://github.com/electron-userland/electron-forge/pull/144

