### PR TITLE
Allowed signWithParams with certificateFile/Password

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,11 @@ export async function createWindowsInstaller(options) {
 
   if (signWithParams) {
     args.push('--signWithParams');
-    args.push(signWithParams);
+    if (!signWithParams.includes('/f') && !signWithParams.includes('/p') && certificateFile && certificatePassword) {
+      args.push(`${signWithParams} /a /f "${path.resolve(certificateFile)}" /p "${certificatePassword}"`);
+    } else {
+      args.push(signWithParams);
+    }
   } else if (certificateFile && certificatePassword) {
     args.push('--signWithParams');
     args.push(`/a /f "${path.resolve(certificateFile)}" /p "${certificatePassword}"`);


### PR DESCRIPTION
Changed the logic in parsing the signWithParams to allow for using them alongside the certificate options, rather than instead of them.

This stems from times I was debugging the signing procedure, or wanted to tweak it, but wished to do so without manually building the arguments for the certificate file and password as well.

To make this change non-breaking, I added a conditional testing that the user-provided signWithParams contain neither /f nor /p, and only in the case that neither of those exists and both certificateFile and certificatePassword are provided, both are used. Otherwise the behavior is just as it currently is.

I would love to hear thoughts about this change, and if there reasons I might be missing why it's a bad idea. I'm also unsure about how to test it - is there a test suite somewhere? Should I build or use an existing minimal project and see that it behaves as expected?

Thanks!