### PR TITLE
Documented "skipUpdateIcon" option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are several configuration settings supported:
 | `signWithParams`      | No       | Params to pass to signtool.  Overrides `certificateFile` and `certificatePassword`. |
 | `iconUrl`             | No       | A URL to an ICO file to use as the application icon (displayed in Control Panel > Programs and Features). Defaults to the Atom icon. |
 | `setupIcon`           | No       | The ICO file to use as the icon for the generated Setup.exe |
-| `skipUpdateIcon`      | No       | When set to true, prevents setupIcon-related error messages "This application could not be started" that may occur during installation. |
+| `skipUpdateIcon`      | No       | Disables setting the icon of `Update.exe`. This can solve installation errors with the following message: "This application could not be started", when the setup is built on a non-Windows system. |
 | `setupExe`            | No       | The name to use for the generated Setup.exe file |
 | `setupMsi`            | No       | The name to use for the generated Setup.msi file |
 | `noMsi`               | No       | Should Squirrel.Windows create an MSI installer? |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ There are several configuration settings supported:
 | `signWithParams`      | No       | Params to pass to signtool.  Overrides `certificateFile` and `certificatePassword`. |
 | `iconUrl`             | No       | A URL to an ICO file to use as the application icon (displayed in Control Panel > Programs and Features). Defaults to the Atom icon. |
 | `setupIcon`           | No       | The ICO file to use as the icon for the generated Setup.exe |
+| `skipUpdateIcon`      | No       | When set to true, prevents setupIcon-related error messages "This application could not be started" that may occur during installation. |
 | `setupExe`            | No       | The name to use for the generated Setup.exe file |
 | `setupMsi`            | No       | The name to use for the generated Setup.msi file |
 | `noMsi`               | No       | Should Squirrel.Windows create an MSI installer? |


### PR DESCRIPTION
The option `skipUpdateIcon` was not documented, but seems necessary when using `setupIcon` to avoid error messages. I could only find it in a comment buried in a closed issue (https://github.com/electron/windows-installer/issues/81#issuecomment-243665425).