### PR TITLE
Update fs-extra to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "asar": "^0.11.0",
     "bluebird": "^3.3.4",
     "debug": "^2.2.0",
-    "fs-extra": "^0.26.7",
+    "fs-extra": "^2.1.2",
     "lodash.template": "^4.2.2",
     "temp": "^0.8.3"
   },


### PR DESCRIPTION
Fixes issue that caused `Unable to load file` when add setupIcon configuration.
see #233