### PR TITLE
fix: Don't try to move nonexistent MSI.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ export async function createWindowsInstaller(options) {
       await fs.rename(unfixedSetupPath, setupPath);
     }
 
-    if (metadata.productName || options.setupMsi) {
+    if (!options.noMsi && (metadata.productName || options.setupMsi)) {
       const msiPath = path.join(outputDirectory, options.setupMsi || `${metadata.productName}Setup.msi`);
       const unfixedMsiPath = path.join(outputDirectory, 'Setup.msi');
       if (await fs.pathExists(unfixedMsiPath)) {


### PR DESCRIPTION
Currently, when passing in the noMsi option, I get this error after it's done:

`ENOENT: no such file or directory, stat 'C:\<wherever>\Setup.msi`

It doesn't actually cause a problem, but that means it shouldn't complain, either. :) This checks that option before attempting to move the MSI.