### PR TITLE
fix: use 64-bit wine when necessary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,77 @@
+step-env: &step-env
+  run:
+    # prevent Wine popup dialogs about installing additional packages
+    name: Setup Environment Variables
+    command: |
+      echo 'export WINEDLLOVERRIDES="mscoree,mshtml="' >> $BASH_ENV
+      echo 'export WINEDEBUG="-all"' >> $BASH_ENV
+
+step-restore-brew-cache: &step-restore-brew-cache
+  restore_cache:
+    name: Restoring Homebrew cache
+    paths:
+      - /usr/local/Homebrew
+    keys:
+      - v1-brew-cache-{{ arch }}
+
+step-save-brew-cache: &step-save-brew-cache
+  save_cache:
+    name: Persisting Homebrew cache
+    paths:
+      - /usr/local/Homebrew
+    key: v1-brew-cache-{{ arch }}
+
 step-restore-cache: &step-restore-cache
   restore_cache:
     keys:
       - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
       - v1-dependencies-{{ arch }}-
 
-steps-test: &steps-test
+step-save-cache: &step-save-cache
+  save_cache:
+    paths:
+      - node_modules
+    key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+
+step-install-os-dependencies: &step-install-os-dependencies
+  run:
+    name: Install OS Dependencies
+    command: |
+      case "$(uname)" in
+        Linux)
+          sudo dpkg --add-architecture i386
+          sudo apt-get -qq update
+          sudo apt-get install --no-install-recommends -y wine64 wine32 wine mono-devel
+          wine64 hostname
+        ;;
+        Darwin)
+          brew untap homebrew/cask-versions
+          brew cask install xquartz wine-stable
+          brew install mono
+          wine64 hostname
+        ;;
+      esac
+
+steps-linux-win: &steps-linux-win
   steps:
-    - run:
-        name: Install OS Dependencies
-        command: |
-          case "$(uname)" in
-            Linux)
-              sudo apt-get -qq update
-              sudo apt-get install --no-install-recommends -y wine-development mono-devel
-              sudo dpkg --add-architecture i386
-              sudo apt-get -qq update
-              sudo apt-get install --no-install-recommends -y wine32-development
-            ;;
-            Darwin)
-              brew install wine mono
-            ;;
-          esac
+    - *step-env
+    - *step-install-os-dependencies
     - checkout
     - *step-restore-cache
     - run: yarn
-    - save_cache:
-        paths:
-          - node_modules
-        key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+    - *step-save-cache
+    - run: yarn test
+
+steps-mac: &steps-mac
+  steps:
+    - *step-env
+    - *step-restore-brew-cache
+    - *step-install-os-dependencies
+    - *step-save-brew-cache
+    - checkout
+    - *step-restore-cache
+    - run: yarn
+    - *step-save-cache
     - run: yarn test
 
 version: 2
@@ -35,11 +79,11 @@ jobs:
   test-linux:
     docker:
       - image: circleci/node:8
-    <<: *steps-test
+    <<: *steps-linux-win
   test-mac:
     macos:
-      xcode: "10.2.0"
-    <<: *steps-test
+      xcode: "11.1.0"
+    <<: *steps-mac
 
   release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ step-install-os-dependencies: &step-install-os-dependencies
           wine64 hostname
         ;;
         Darwin)
-          brew untap homebrew/cask-versions
           brew cask install xquartz wine-stable
           brew install mono
           wine64 hostname

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export async function createWindowsInstaller(options: Options): Promise<void> {
   let useMono = false;
 
   const monoExe = 'mono';
-  const wineExe = 'wine';
+  const wineExe = process.arch === 'x64' ? 'wine64' : 'wine';
 
   if (process.platform !== 'win32') {
     useMono = true;


### PR DESCRIPTION
On 64-bit macOS/Linux, use `wine64` instead of `wine`. This should fix some (but not all) problems with running this module on macOS Catalina (10.15).

This also fixes the macOS CI. It is currently pinned to macOS 10.14 due to the Catalina issues.