### PR TITLE
fix: update default iconUrl value since it moved

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export async function createWindowsInstaller(options: Options): Promise<void> {
 
   const metadata: Metadata = {
     description: '',
-    iconUrl: 'https://raw.githubusercontent.com/atom/electron/master/atom/browser/resources/win/atom.ico'
+    iconUrl: 'https://raw.githubusercontent.com/electron/electron/master/shell/browser/resources/win/electron.ico'
   };
 
   if (options.usePackageJson !== false) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -86,7 +86,7 @@ export interface Options {
    *
    * Does not accept `file:` URLs.
    *
-   * Defaults to the Atom icon.
+   * Defaults to the Electron icon.
    */
   iconUrl?: string;
   /**


### PR DESCRIPTION
The icon in the Electron repository was moved a while ago but it wasn't updated here.