### PR TITLE
fix: add missing Electron files in the nuget template

### DIFF
--- a/template.nuspectemplate
+++ b/template.nuspectemplate
@@ -14,6 +14,8 @@
   <files>
     <file src="locales\**" target="lib\net45\locales" />
     <file src="resources\**" target="lib\net45\resources" />
+    <file src="swiftshader\**" target="lib\net45\swiftshader" />
+    <file src="vk_swiftshader_icd.json" target="lib\net45" />
     <file src="*.bin" target="lib\net45" />
     <file src="*.dll" target="lib\net45" />
     <file src="*.pak" target="lib\net45" />


### PR DESCRIPTION
This adds `swiftshader` dir and the `vk_swiftshader_icd.json` file into the package template, so that they would be included into the distribution.

Without `swiftshader` dir, Electron crashes at launch with "Failed to launch GPU process" error on some setups.

To reproduce: build an installer, run in a Windows VM with GPU acceleration disabled.
Alternatively: with no vendor GPU drivers installed, just the default Microsoft one.

cc @MarshallOfSound 