### PR TITLE
ci: Use brew install --cask to fix macOS CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ step-install-os-dependencies: &step-install-os-dependencies
           wine64 hostname
         ;;
         Darwin)
-          brew cask install xquartz wine-stable
+          brew install --cask xquartz wine-stable
           brew install mono
           wine64 hostname
         ;;


### PR DESCRIPTION
Should address recent CI failures on macOS by using `brew install --cask` instead of the deprecated `brew cask` command.