### PR TITLE
feat!: rename Options to SquirrelConfigOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import * as asar from 'asar';
 import { createTempDir } from './temp-utils';
 import * as fs from 'fs-extra';
-import { Metadata, Options, PersonMetadata } from './options';
+import { Metadata, SquirrelWindowsOptions, PersonMetadata } from './options';
 import * as path from 'path';
 import spawn from './spawn-promise';
 import template from 'lodash.template';
 
-export { Options } from './options';
+export { SquirrelWindowsOptions } from './options';
 
 const log = require('debug')('electron-windows-installer:main');
 
@@ -22,7 +22,7 @@ export function convertVersion(version: string): string {
 }
 
 
-export async function createWindowsInstaller(options: Options): Promise<void> {
+export async function createWindowsInstaller(options: SquirrelWindowsOptions): Promise<void> {
   let useMono = false;
 
   const monoExe = 'mono';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import spawn from './spawn-promise';
 import template from 'lodash.template';
 
 export { SquirrelWindowsOptions } from './options';
+export { SquirrelWindowsOptions as Options} from './options';
 
 const log = require('debug')('electron-windows-installer:main');
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,7 +2,7 @@
 // Original definitions by: Brendan Forster <https://github.com/shiftkey>, Daniel Perez Alvarez <https://github.com/unindented>
 // Original definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export interface Options {
+export interface SquirrelWindowsOptions {
   /**
    * The folder path of your Electron app
    */


### PR DESCRIPTION
This change aims to increase the type clarity of winstaller's `options`.  This will increase readability in our docs when documenting types for Squirrel.Windows. 

<img width="772" alt="image" src="https://user-images.githubusercontent.com/33054982/197032421-9d58fa02-321e-41d7-814a-f8dd447d2ad4.png">
