### PR TITLE
fix: Drop build metadata part in convertVersion

### DIFF
--- a/spec/convert-version-spec.ts
+++ b/spec/convert-version-spec.ts
@@ -9,4 +9,6 @@ test('makes semver versions into valid NuGet versions', (t): void => {
   t.is(convertVersion('1.2.3-alpha.1'), '1.2.3-alpha1');
   t.is(convertVersion('1.2.3-alpha.1.2'), '1.2.3-alpha12');
   t.is(convertVersion('1.2.3-alpha-1-2'), '1.2.3-alpha-1-2');
+  t.is(convertVersion('1.2.3-alpha.1.2+build-meta.1.2'), '1.2.3-alpha12');
+  t.is(convertVersion('1.2.3-alpha-1-2+build-meta.1.2'), '1.2.3-alpha-1-2');
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export { SquirrelWindowsOptions as Options} from './options';
 const log = require('debug')('electron-windows-installer:main');
 
 export function convertVersion(version: string): string {
-  const parts = version.split('-');
+  const parts = version.split('+')[0].split('-');
   const mainVersion = parts.shift();
 
   if (parts.length > 0) {


### PR DESCRIPTION
I assume the purpose of `convertVersion` is to convert the version string to semver 1.0 standard which Squirrel can support. So it might as well drop the build metadata part specified in [semver 2.0](https://semver.org/spec/v2.0.0.html#spec-item-10), denoted by a `+` sign. Since by specification, the build metadata has no effect on precedence, I think it makes sense to simply discard it instead of incorporating it.