### PR TITLE
fix: Corrected the verification of Mono and Wine installation status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,10 +42,12 @@ export async function createWindowsInstaller(options: SquirrelWindowsOptions): P
 
   if (process.platform !== 'win32') {
     useMono = true;
-    const isWineInstalled = await checkIfCommandExists(wineExe);
-    const isMonoInstalled = await checkIfCommandExists(monoExe);
+    const [hasWine, hasMono] = await Promise.all([
+      checkIfCommandExists(wineExe),
+      checkIfCommandExists(monoExe)
+    ]);
 
-    if (!isWineInstalled || !isMonoInstalled) {
+    if (!hasWine || !hasMono) {
       throw new Error('You must install both Mono and Wine on non-Windows');
     }
 


### PR DESCRIPTION
The old code wrongly checked if Mono and Wine were installed. It looked like this:

https://github.com/electron/windows-installer/blob/073930d4845432adb2f16891c81066249cf99c71/src/index.ts#L26-L40

The part `(!wineExe || !monoExe)` didn't work right because wineExe and monoExe were just text, not real checks.

Now, the code really checks if Wine and Mono are there. This fix makes sure the setup works right and checks everything needed.
