### PR TITLE
test: bump ava test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "tsc",
     "prepublish": "npm run build",
     "lint": "eslint --ext .ts src spec",
-    "test": "npm run lint && ava",
+    "test": "npm run lint && ava --timeout=30s",
     "tdd": "ava --watch"
   },
   "dependencies": {


### PR DESCRIPTION
The default timeout is 10s and we keep tripping it on Windows CI.