### PR TITLE
fix: use wine64 on arm64 arch

### DIFF
--- a/spec/installer-spec.ts
+++ b/spec/installer-spec.ts
@@ -11,7 +11,7 @@ const fixtureAppDirectory = path.join(__dirname, 'fixtures/app');
 
 function spawn7z(args: string[]): Promise<string> {
   const sevenZipPath = path.join(__dirname, '..', 'vendor', '7z.exe');
-  const wineExe = process.arch === 'x64' ? 'wine64' : 'wine';
+  const wineExe = ['arm64', 'x64'].includes(process.arch) ? 'wine64' : 'wine';
   return process.platform !== 'win32'
     ? spawn(wineExe, [sevenZipPath, ...args])
     : spawn(sevenZipPath, args);

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export async function createWindowsInstaller(options: SquirrelWindowsOptions): P
   let useMono = false;
 
   const monoExe = 'mono';
-  const wineExe = process.arch === 'x64' ? 'wine64' : 'wine';
+  const wineExe = ['arm64', 'x64'].includes(process.arch) ? 'wine64' : 'wine';
 
   if (process.platform !== 'win32') {
     useMono = true;


### PR DESCRIPTION
Alternative to #380. Long-term I'd prefer to use `is64BitArch` from `cross-spawn-windows-exe` (like `node-rcedit` does) which we should probably be using anyway, but that will require a breaking change.