### PR TITLE
Respect WINE_BINARY env var

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export async function createWindowsInstaller(options: SquirrelWindowsOptions): P
   let useMono = false;
 
   const monoExe = 'mono';
-  const wineExe = ['arm64', 'x64'].includes(process.arch) ? 'wine64' : 'wine';
+  const wineExe = process.env.WINE_BINARY || ['arm64', 'x64'].includes(process.arch) ? 'wine64' : 'wine';
 
   if (process.platform !== 'win32') {
     useMono = true;


### PR DESCRIPTION
In ubuntu for example there is no `wine64` binary at all.
In `cross-spawn-windows-exe` package it is possible to overwrite it with `WINE_BINARY` env var
https://github.com/malept/cross-spawn-windows-exe/blob/8b622a5e487e45ecd316d5fe7b53750b7587035d/src/exe.ts#L40