### PR TITLE
chore: remove semver dependency

### DIFF
--- a/spec/sign-spec.ts
+++ b/spec/sign-spec.ts
@@ -5,11 +5,10 @@ import fs from 'fs-extra';
 import { createWindowsInstaller } from '../src';
 import { createTempAppDirectory } from './helpers/helpers';
 import { SignToolOptions } from '@electron/windows-sign';
-import semver from 'semver';
 
 const log = require('debug')('electron-windows-installer:spec');
 
-if (process.platform === 'win32' && semver.gte(process.version, '20.0.0')) {
+if (process.platform === 'win32' && process.versions.node.split('.')[0] > '20') {
   test.serial('creates a signtool.exe and uses it to sign', async (t): Promise<void> => {
 
     const outputDirectory = await createTempDir('ei-');

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -1,6 +1,5 @@
 import type { createSeaSignTool as createSeaSignToolType } from '@electron/windows-sign';
 import path from 'path';
-import semver from 'semver';
 import fs from 'fs-extra';
 
 import { SquirrelWindowsOptions } from './options';
@@ -78,7 +77,7 @@ async function getCreateSeaSignTool(): Promise<typeof createSeaSignToolType> {
   } catch(error) {
     let message  = 'In order to use windowsSign options, @electron/windows-sign must be installed as a dependency.';
 
-    if (semver.lte(process.version, '20.0.0')) {
+    if (process.versions.node.split('.')[0] < '20') {
       message += ` You are currently using Node.js ${process.version}. Please upgrade to Node.js 19 or later and reinstall all dependencies to ensure that @electron/windows-sign is available.`;
     } else {
       message += ` ${error}`;


### PR DESCRIPTION
Simplify logic to check Node version and remove the use of `semver` dependency.

Fix #516