### PR TITLE
ci: revert runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           - '16.20'
           - '14.21'
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - windows-latest
     runs-on: "${{ matrix.os }}"
     env:
@@ -30,7 +30,7 @@ jobs:
       WINEDEBUG: -all
     steps:
       - name: Install Dependencies (Linux)
-        if : ${{ matrix.os == 'ubuntu-latest' }}
+        if : ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get -qq update


### PR DESCRIPTION
`ubuntu-latest` is now Ubuntu 24.04 and an issue has cropped up where `wine64` isn't found despite installing successfully. To unblock CI here for now, revert to Ubuntu 22.04 until that issue can be debugged.