### PR TITLE
ci: bump Node.js 20 version to 20.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '20.10'
+          - '20.19'
           - '18.18'
           - '16.20'
           - '14.21'
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "${{ matrix.node-version }}"
           cache: 'yarn'


### PR DESCRIPTION
Same changes as https://github.com/electron/asar/pull/365/, for some reason the Node.js 20.10 and Ubuntu 22.04 job has consistently been stalled indefinitely at the install step, but bumping this gets it back to working. 🤷 