### PR TITLE
fix: correct Mono/Wine check on non-Windows systems

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,12 @@ export async function createWindowsInstaller(options: SquirrelWindowsOptions): P
       checkIfCommandExists(monoExe)
     ]);
 
-    if (!hasWine || !hasMono) {
+    if (!hasWine && !hasMono) {
       throw new Error('You must install both Mono and Wine on non-Windows');
+    } else if (!hasWine) {
+      throw new Error('You must install Wine on non-Windows');
+    } else if (!hasMono) {
+      throw new Error('You must install Mono on non-Windows');
     }
 
     log(`Using Mono: '${monoExe}'`);


### PR DESCRIPTION
Original logic used `or`, which threw an error if either Wine or Mono was
missing, even when the other was present. Updated to require both, with
separate errors for missing Wine or missing Mono.