### PR TITLE
feat: add more details on missing commands error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,10 @@ export async function createWindowsInstaller(options: SquirrelWindowsOptions): P
     ]);
 
     if (!hasWine || !hasMono) {
-      throw new Error('You must install both Mono and Wine on non-Windows');
+      const missing = [];
+      if (!hasWine) missing.push(wineExe);
+      if (!hasMono) missing.push(monoExe);
+      throw new Error(`You must install both Mono and Wine on non-Windows. Missing: ${missing.join(', ')}`);
     }
 
     log(`Using Mono: '${monoExe}'`);


### PR DESCRIPTION
Hello,

here's a little contribution to improve experience

BEFORE:
- work is needed to find out which of wine or mono is missing
- references here:
  - https://github.com/electron/windows-installer/pull/562
  - https://github.com/electron/forge/issues/3778

AFTER:
- it is indicated in the error message