### PR TITLE
build: drop npx from docs script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "install": "node ./script/select-7z-arch.js",
     "build": "tsc",
-    "docs": "npx typedoc",
+    "docs": "typedoc",
     "prepublish": "npm run build",
     "lint": "eslint --ext .ts src spec",
     "ava": "ava --timeout=60s",


### PR DESCRIPTION
typedoc is already a devDependency — `npx` is redundant.