### PR TITLE
refactor: replace temp package with Node built-in fs.mkdtemp

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,12 @@
     "debug": "^4.1.1",
     "fs-extra": "^7.0.1",
     "lodash": "^4.17.21",
-    "semver": "^7.6.3",
-    "temp": "^0.9.0"
+    "semver": "^7.6.3"
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.5",
     "@types/lodash": "^4.17.0",
     "@types/node": "^20.6.0",
-    "@types/temp": "^0.8.34",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "ava": "^5.1.1",

--- a/src/temp-utils.ts
+++ b/src/temp-utils.ts
@@ -1,8 +1,11 @@
-import * as temp from 'temp';
+import { mkdtemp } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { promisify } from 'util';
-temp.track();
 
-const createTempDir = promisify(temp.mkdir);
+const mkdtempAsync = promisify(mkdtemp);
+
+const createTempDir = (prefix: string) => mkdtempAsync(join(tmpdir(), prefix));
 
 export {
   createTempDir


### PR DESCRIPTION
## What

Replace the `temp` package with Node's built-in `fs.mkdtemp` + `os.tmpdir`.

## Why

The `temp` package (v0.9.4) was last released in November 2020 and is effectively unmaintained. It pins deprecated transitive dependencies:

```
temp@0.9.4 -> rimraf@~2.6.2 -> glob@7.2.3 -> inflight@1.0.6
```

All four packages are deprecated. `inflight` is also flagged for memory leaks (CWE-772).

The only usage of `temp` in this project is creating a single temporary directory via `createTempDir('si-')` in `src/index.ts:161`, which maps directly to Node's built-in `fs.mkdtemp`.

## Changes

- **`src/temp-utils.ts`**: Replace `temp.mkdir` with `fs.mkdtemp` + `os.tmpdir` + `path.join`
- **`package.json`**: Remove `temp` from dependencies and `@types/temp` from devDependencies

## Compatibility

- `fs.mkdtemp` has been stable since Node 5.10.0
- `util.promisify` has been stable since Node 8.0.0
- Both are within the existing engine requirement of `>=8.0.0`
- The exported `createTempDir` function signature and return type are unchanged

## Notes

This is a revival of #584 (closed by the original author). The approach is identical — the only difference is using `path.join(tmpdir(), prefix)` for clarity.

Closes #581